### PR TITLE
Improvment of the interface

### DIFF
--- a/LibJpegWrapper/Quamotion.TurboJpegWrapper.csproj
+++ b/LibJpegWrapper/Quamotion.TurboJpegWrapper.csproj
@@ -12,8 +12,8 @@
     <Company>Quamotion</Company>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/qmfrederik/AS.TurboJpegWrapper</RepositoryUrl>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <VersionPrefix>1.0.3</VersionPrefix>
+    <AllowUnsafeBlocks>false</AllowUnsafeBlocks>
+    <VersionPrefix>1.0.4</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">

--- a/LibJpegWrapper/TJCompressor.cs
+++ b/LibJpegWrapper/TJCompressor.cs
@@ -14,7 +14,7 @@ namespace TurboJpegWrapper
     {
         private IntPtr _compressorHandle;
         private bool _isDisposed;
-        private readonly object _lock = new object();
+        private readonly object _lock;
 
         /// <summary>
         /// Creates new instance of <see cref="TJCompressor"/>
@@ -25,6 +25,7 @@ namespace TurboJpegWrapper
         public TJCompressor()
         {
             _compressorHandle = TurboJpegImport.tjInitCompress();
+            _lock = new object();
 
             if (_compressorHandle == IntPtr.Zero)
             {
@@ -62,14 +63,13 @@ namespace TurboJpegWrapper
             var height = srcImage.Height;
             // ReSharper disable once ExceptionNotDocumented
             var srcData = srcImage.LockBits(new Rectangle(0, 0, width, height), ImageLockMode.ReadOnly, pixelFormat);
-
-            var stride = srcData.Stride;
-            var srcPtr = srcData.Scan0;
+            // BitmapData.Stride may be negative if the bitmap is bottom up. In this case, BitmapData.Scan0 is the last scan line -> recalculate start of unmanaged memory
+            var stride = Math.Abs(srcData.Stride);
+            var srcPtr = srcData.Stride > 0 ? srcData.Scan0 : srcData.Scan0 - ((srcData.Height - 1) * stride);
 
             try
             {
                 return Compress(srcPtr, stride, width, height, pixelFormat, subSamp, quality, flags);
-
             }
             finally
             {
@@ -78,6 +78,63 @@ namespace TurboJpegWrapper
             }
         }
 
+
+        /// <summary>
+        /// Compresses input image to the jpeg format with specified quality
+        /// </summary>
+        /// <param name="srcPtr">Pointer to an image buffer containing RGB, grayscale, or CMYK pixels to be compressed.
+        /// This buffer is not modified.</param>
+        /// <param name="stride">Bytes per line in the source image.
+        /// Normally, this should be <c>width * BytesPerPixel</c> if the image is unpadded,
+        /// or <c>TJPAD(width * BytesPerPixel</c> if each line of the image
+        /// is padded to the nearest 32-bit boundary, as is the case for Windows bitmaps.
+        /// You can also be clever and use this parameter to skip lines, etc.
+        /// Setting this parameter to 0 is the equivalent of setting it to
+        /// <c>width * BytesPerPixel</c>.</param>
+        /// <param name="width">Width (in pixels) of the source image</param>
+        /// <param name="height">Height (in pixels) of the source image</param>
+        /// <param name="pixelFormat">Pixel format of the source image (see <see cref="PixelFormat" /> "Pixel formats")</param>
+        /// <param name="subSamp">The level of chrominance subsampling to be used when
+        /// generating the JPEG image (see <see cref="TJSubsamplingOptions" /> "Chrominance subsampling options".)</param>
+        /// <param name="quality">The image quality of the generated JPEG image (1 = worst, 100 = best)</param>
+        /// <param name="flags">The bitwise OR of one or more of the <see cref="TJFlags" /> "flags"</param>
+        /// <param name="bufSize">Size of the returned unmanaged buffer (in bytes).</param>
+        /// <returns></returns>
+        /// <exception cref="System.ObjectDisposedException">this</exception>
+        /// <exception cref="TJException">Throws if compress function failed</exception>
+        /// <exception cref="ObjectDisposedException">Object is disposed and can not be used anymore</exception>
+        /// <exception cref="NotSupportedException">Some parameters' values are incompatible:
+        /// <list type="bullet"><item><description>Subsampling not equals to <see cref="TJSubsamplingOptions.TJSAMP_GRAY" /> and pixel format <see cref="TJPixelFormats.TJPF_GRAY" /></description></item></list></exception>
+        public TJUnmanagedMemory Compress(IntPtr srcPtr, int stride, int width, int height, PixelFormat pixelFormat, TJSubsamplingOptions subSamp, int quality, TJFlags flags, out ulong bufSize)
+        {
+            if (_isDisposed)
+                throw new ObjectDisposedException("this");
+
+            var tjPixelFormat = TJUtils.ConvertPixelFormat(pixelFormat);
+            CheckOptionsCompatibilityAndThrow(subSamp, tjPixelFormat);
+
+            var buf = IntPtr.Zero;
+            bufSize = 0;
+            var result = TurboJpegImport.tjCompress2(
+                _compressorHandle,
+                srcPtr,
+                width,
+                stride,
+                height,
+                (int)tjPixelFormat,
+                ref buf,
+                ref bufSize,
+                (int)subSamp,
+                quality,
+                (int)flags);
+
+            if (result == -1)
+            {
+                TJUtils.GetErrorAndThrow();
+            }
+
+            return new TJUnmanagedMemory(buf, bufSize);
+        }
 
         /// <summary>
         /// Compresses input image to the jpeg format with specified quality
@@ -114,43 +171,8 @@ namespace TurboJpegWrapper
         /// </exception>
         public byte[] Compress(IntPtr srcPtr, int stride, int width, int height, PixelFormat pixelFormat, TJSubsamplingOptions subSamp, int quality, TJFlags flags)
         {
-            if (_isDisposed)
-                throw new ObjectDisposedException("this");
-
-            var tjPixelFormat = TJUtils.ConvertPixelFormat(pixelFormat);
-            CheckOptionsCompatibilityAndThrow(subSamp, tjPixelFormat);
-
-            var buf = IntPtr.Zero;
-            ulong bufSize = 0;
-            try
-            {
-                var result = TurboJpegImport.tjCompress2(
-                    _compressorHandle,
-                    srcPtr,
-                    width,
-                    stride,
-                    height,
-                    (int)tjPixelFormat,
-                    ref buf,
-                    ref bufSize,
-                    (int)subSamp,
-                    quality,
-                    (int)flags);
-
-                if (result == -1)
-                {
-                    TJUtils.GetErrorAndThrow();
-                }
-
-                var jpegBuf = new byte[bufSize];
-                // ReSharper disable once ExceptionNotDocumentedOptional
-                Marshal.Copy(buf, jpegBuf, 0, (int)bufSize);
-                return jpegBuf;
-            }
-            finally
-            {
-                TurboJpegImport.tjFree(buf);
-            }
+            ulong bufSize;
+            return Compress(srcPtr, stride, width, height, pixelFormat, subSamp, quality, flags, out bufSize);
         }
 
         /// <summary>
@@ -188,47 +210,13 @@ namespace TurboJpegWrapper
         /// <item><description>Subsampling not equals to <see cref="TJSubsamplingOptions.TJSAMP_GRAY"/> and pixel format <see cref="TJPixelFormats.TJPF_GRAY"/></description></item>
         /// </list>
         /// </exception>
-        public unsafe byte[] Compress(byte[] srcBuf, int stride, int width, int height, PixelFormat pixelFormat, TJSubsamplingOptions subSamp, int quality, TJFlags flags)
+        public byte[] Compress(byte[] srcBuf, int stride, int width, int height, PixelFormat pixelFormat, TJSubsamplingOptions subSamp, int quality, TJFlags flags)
         {
             if (_isDisposed)
                 throw new ObjectDisposedException("this");
 
-            var tjPixelFormat = TJUtils.ConvertPixelFormat(pixelFormat);
-            CheckOptionsCompatibilityAndThrow(subSamp, tjPixelFormat);
-            
-            var buf = IntPtr.Zero;
-            ulong bufSize = 0;
-            try
-            {
-                fixed (byte* srcBufPtr = srcBuf)
-                {
-                    var result = TurboJpegImport.tjCompress2(
-                        _compressorHandle,
-                        (IntPtr)srcBufPtr,
-                        width,
-                        stride,
-                        height,
-                        (int)tjPixelFormat,
-                        ref buf,
-                        ref bufSize,
-                        (int)subSamp,
-                        quality,
-                        (int)flags);
-                    if (result == -1)
-                    {
-                        TJUtils.GetErrorAndThrow();
-                    }
-                }
-
-                var jpegBuf = new byte[bufSize];
-                // ReSharper disable once ExceptionNotDocumentedOptional
-                Marshal.Copy(buf, jpegBuf, 0, (int)bufSize);
-                return jpegBuf;
-            }
-            finally
-            {
-                TurboJpegImport.tjFree(buf);
-            }
+            using (var srcPtr = new TJUnmanagedMemory(srcBuf))
+                return Compress((IntPtr)srcPtr, stride, width, height, pixelFormat, subSamp, quality, flags);
         }
 
         /// <summary>
@@ -293,5 +281,4 @@ namespace TurboJpegWrapper
                     $"Subsampling differ from {TJSubsamplingOptions.TJSAMP_GRAY} for pixel format {TJPixelFormats.TJPF_GRAY} is not supported");
         }
     }
-
 }

--- a/LibJpegWrapper/TJDecompressor.cs
+++ b/LibJpegWrapper/TJDecompressor.cs
@@ -11,9 +11,23 @@ namespace TurboJpegWrapper
     /// </summary>
     public class TJDecompressor : IDisposable
     {
-        private IntPtr _decompressorHandle = IntPtr.Zero;
+        private static ColorPalette _grayscalePalette;
+        private IntPtr _decompressorHandle;
         private bool _isDisposed;
-        private readonly object _lock = new object();
+        private readonly object _lock;
+
+        /// <summary>
+        /// Static constructor to create grayscale palette object
+        /// </summary>
+        static TJDecompressor()
+        {
+            using (var bitmap = new Bitmap(1, 1, PixelFormat.Format8bppIndexed)) // a ColorPalette cannot be created. Therefore, create a dummy Bitmap to get a template from
+            {
+                _grayscalePalette = bitmap.Palette;
+                for (var index = 0; index < _grayscalePalette.Entries.Length; ++index) // set the Color entries to grayscale
+                    _grayscalePalette.Entries[index] = Color.FromArgb(index, index, index);
+            }
+        }
 
         /// <summary>
         /// Creates new instance of <see cref="TJDecompressor"/>
@@ -23,6 +37,7 @@ namespace TurboJpegWrapper
         /// </exception>
         public TJDecompressor()
         {
+            _lock = new object();
             _decompressorHandle = TurboJpegImport.tjInitDecompress();
 
             if (_decompressorHandle == IntPtr.Zero)
@@ -44,46 +59,72 @@ namespace TurboJpegWrapper
         /// <returns>Raw pixel data of specified format</returns>
         /// <exception cref="TJException">Throws if underlying decompress function failed</exception>
         /// <exception cref="ObjectDisposedException">Object is disposed and can not be used anymore</exception>
-        public unsafe byte[] Decompress(IntPtr jpegBuf, ulong jpegBufSize, TJPixelFormats destPixelFormat, TJFlags flags, out int width, out int height, out int stride)
-        {
-            int outBufSize;
-            this.GetImageInfo(jpegBuf, jpegBufSize, destPixelFormat, out width, out height, out stride, out outBufSize);
-
-            var buf = new byte[outBufSize];
-
-            fixed (byte* bufPtr = buf)
-            {
-                this.Decompress(jpegBuf, jpegBufSize, (IntPtr)bufPtr, outBufSize, destPixelFormat, flags, out width, out height, out stride);
-            }
-
-            return buf;
-        }
-
-        public unsafe void Decompress(IntPtr jpegBuf, ulong jpegBufSize, IntPtr outBuf, int outBufSize, TJPixelFormats destPixelFormat, TJFlags flags, out int width, out int height, out int stride)
+        public byte[] Decompress(IntPtr jpegBuf, ulong jpegBufSize, TJPixelFormats destPixelFormat, TJFlags flags, out int width, out int height, out int stride)
         {
             if (_isDisposed)
                 throw new ObjectDisposedException("this");
 
-            int subsampl;
-            int colorspace;
-            var funcResult = TurboJpegImport.tjDecompressHeader(_decompressorHandle, jpegBuf, jpegBufSize,
-                out width, out height, out subsampl, out colorspace);
+            int outBufSize;
+            GetImageInfo(jpegBuf, jpegBufSize, destPixelFormat, out width, out height, out stride, out outBufSize);
 
-            if (funcResult == -1)
+            using (var outBuf = new TJUnmanagedMemory(outBufSize))
             {
-                TJUtils.GetErrorAndThrow();
+                DecompressInternal(jpegBuf, jpegBufSize, outBuf, outBufSize, destPixelFormat, flags, width, height, stride);
+                return outBuf;
             }
+        }
 
-            var targetFormat = destPixelFormat;
-            stride = TurboJpegImport.TJPAD(width * TurboJpegImport.PixelSizes[targetFormat]);
-            var bufSize = stride * height;
+        /// <summary>
+        /// Decompress a JPEG image to an RGB, grayscale, or CMYK image.
+        /// </summary>
+        /// <param name="jpegBuf">Pointer to a buffer containing the JPEG image to decompress. This buffer is not modified</param>
+        /// <param name="jpegBufSize">Size of the JPEG image (in bytes)</param>
+        /// <param name="outBuf">Buffer of unmanaged memory to hold the decompressed image</param>
+        /// <param name="outBufSize">Size of the output buffer (in bytes)</param>
+        /// <param name="destPixelFormat">Pixel format of the destination image (see <see cref="PixelFormat"/> "Pixel formats".)</param>
+        /// <param name="flags">The bitwise OR of one or more of the <see cref="TJFlags"/> "flags"</param>
+        /// <param name="width">Width of image in pixels</param>
+        /// <param name="height">Height of image in pixels</param>
+        /// <param name="stride">Bytes per line in the destination image</param>
+        /// <returns>Raw pixel data of specified format</returns>
+        /// <exception cref="TJException">Throws if underlying decompress function failed</exception>
+        /// <exception cref="ObjectDisposedException">Object is disposed and can not be used anymore</exception>
+        public void Decompress(IntPtr jpegBuf, ulong jpegBufSize, IntPtr outBuf, int outBufSize, TJPixelFormats destPixelFormat, TJFlags flags, out int width, out int height, out int stride)
+        {
+            if (_isDisposed)
+                throw new ObjectDisposedException("this");
+
+            int bufSize;
+            GetImageInfo(jpegBuf, jpegBufSize, destPixelFormat, out width, out height, out stride, out bufSize);
 
             if (outBufSize < bufSize)
             {
                 throw new ArgumentOutOfRangeException(nameof(outBufSize));
             }
 
-            funcResult = TurboJpegImport.tjDecompress(
+            DecompressInternal(jpegBuf, jpegBufSize, outBuf, outBufSize, destPixelFormat, flags, width, height, stride);
+        }
+
+        /// <summary>
+        /// Internal method to decompress a JPEG image to an RGB, grayscale, or CMYK image.
+        /// </summary>
+        /// <param name="jpegBuf">Pointer to a buffer containing the JPEG image to decompress. This buffer is not modified</param>
+        /// <param name="jpegBufSize">Size of the JPEG image (in bytes)</param>
+        /// <param name="outBuf">Buffer of unmanaged memory to hold the decompressed image</param>
+        /// <param name="outBufSize">Size of the output buffer (in bytes)</param>
+        /// <param name="destPixelFormat">Pixel format of the destination image (see <see cref="PixelFormat" /> "Pixel formats".)</param>
+        /// <param name="flags">The bitwise OR of one or more of the <see cref="TJFlags" /> "flags"</param>
+        /// <param name="width">Width of image in pixels</param>
+        /// <param name="height">Height of image in pixels</param>
+        /// <param name="stride">Bytes per line in the destination image</param>
+        /// <exception cref="ObjectDisposedException">Object is disposed and can not be used anymore</exception>
+        /// <exception cref="TJException">Throws if underlying decompress function failed</exception>
+        private void DecompressInternal(IntPtr jpegBuf, ulong jpegBufSize, IntPtr outBuf, int outBufSize, TJPixelFormats destPixelFormat, TJFlags flags, int width, int height, int stride)
+        {
+            if (_isDisposed)
+                throw new ObjectDisposedException("this");
+
+            var funcResult = TurboJpegImport.tjDecompress(
                 _decompressorHandle,
                 jpegBuf,
                 jpegBufSize,
@@ -91,7 +132,7 @@ namespace TurboJpegWrapper
                 width,
                 stride,
                 height,
-                (int)targetFormat,
+                (int)destPixelFormat,
                 (int)flags);
 
             if (funcResult == -1)
@@ -112,16 +153,14 @@ namespace TurboJpegWrapper
         /// <returns>Raw pixel data of specified format</returns>
         /// <exception cref="TJException">Throws if underlying decompress function failed</exception>
         /// <exception cref="ObjectDisposedException">Object is disposed and can not be used anymore</exception>
-        public unsafe byte[] Decompress(byte[] jpegBuf, TJPixelFormats destPixelFormat, TJFlags flags, out int width, out int height, out int stride)
+        public byte[] Decompress(byte[] jpegBuf, TJPixelFormats destPixelFormat, TJFlags flags, out int width, out int height, out int stride)
         {
             if (_isDisposed)
                 throw new ObjectDisposedException("this");
 
             var jpegBufSize = (ulong)jpegBuf.Length;
-            fixed (byte* jpegPtr = jpegBuf)
-            {
-                return Decompress((IntPtr)jpegPtr, jpegBufSize, destPixelFormat, flags, out width, out height, out stride);
-            }
+            using (var jpegBufPtr = new TJUnmanagedMemory(jpegBuf))
+                return Decompress(jpegBufPtr, jpegBufSize, destPixelFormat, flags, out width, out height, out stride);
         }
 
         /// <summary>
@@ -135,7 +174,7 @@ namespace TurboJpegWrapper
         /// <exception cref="TJException">Throws if underlying decompress function failed</exception>
         /// <exception cref="ObjectDisposedException">Object is disposed and can not be used anymore</exception>
         /// <exception cref="NotSupportedException">Convertion to the requested pixel format can not be performed</exception>
-        public unsafe Bitmap Decompress(IntPtr jpegBuf, ulong jpegBufSize, PixelFormat destPixelFormat, TJFlags flags)
+        public Bitmap Decompress(IntPtr jpegBuf, ulong jpegBufSize, PixelFormat destPixelFormat, TJFlags flags)
         {
             if (_isDisposed)
                 throw new ObjectDisposedException("this");
@@ -144,15 +183,68 @@ namespace TurboJpegWrapper
             int width;
             int height;
             int stride;
-            var buffer = Decompress(jpegBuf, jpegBufSize, targetFormat, flags, out width, out height, out stride);
-            Bitmap result;
-            fixed (byte* bufferPtr = buffer)
+            int outBufSize;
+            GetImageInfo(jpegBuf, jpegBufSize, targetFormat, out width, out height, out stride, out outBufSize);
+
+            var result = new Bitmap(width, height, destPixelFormat);
+            var dstData = result.LockBits(new Rectangle(0, 0, width, height), ImageLockMode.WriteOnly, destPixelFormat);
+            try
             {
-                result = new Bitmap(width, height, stride, destPixelFormat, (IntPtr)bufferPtr);
-                if (destPixelFormat == PixelFormat.Format8bppIndexed)
-                {
-                    result.Palette = FixPaletteToGrayscale(result.Palette);
-                }
+                // BitmapData.Stride may be negative if the bitmap is bottom up. In this case, BitmapData.Scan0 is the last scan line -> recalculate start of unmanaged memory
+                stride = Math.Abs(dstData.Stride); // use actual stride from GDI Bitmap
+                var dstPtr = dstData.Stride > 0 ? dstData.Scan0 : dstData.Scan0 - ((dstData.Height - 1) * stride);
+                DecompressInternal(jpegBuf, jpegBufSize, dstPtr, stride * height, targetFormat, flags, width, height, stride);
+            }
+            finally
+            {
+                result.UnlockBits(dstData);
+            }
+            if (destPixelFormat == PixelFormat.Format8bppIndexed)
+            {
+                result.Palette = _grayscalePalette;
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Decompress a JPEG image to an RGB, grayscale, or CMYK image.
+        /// </summary>
+        /// <param name="jpegBuf">Pointer to a buffer containing the JPEG image to decompress. This buffer is not modified</param>
+        /// <param name="jpegBufSize">Size of the JPEG image (in bytes)</param>
+        /// <returns>Decompressed image of specified format</returns>
+        /// <exception cref="TJException">Throws if underlying decompress function failed</exception>
+        /// <exception cref="ObjectDisposedException">Object is disposed and can not be used anymore</exception>
+        /// <exception cref="NotSupportedException">Convertion to the requested pixel format can not be performed</exception>
+        public Bitmap Decompress(IntPtr jpegBuf, ulong jpegBufSize)
+        {
+            if (_isDisposed)
+                throw new ObjectDisposedException("this");
+
+            TJPixelFormats targetFormat;
+            var flags = TJFlags.BOTTOMUP;
+            int width;
+            int height;
+            int stride;
+            int outBufSize;
+            GetImageInfo(jpegBuf, jpegBufSize, out targetFormat, out width, out height, out stride, out outBufSize);
+
+            var destPixelFormat = TJUtils.ConvertPixelFormat(targetFormat);
+            var result = new Bitmap(width, height, destPixelFormat);
+            var dstData = result.LockBits(new Rectangle(0, 0, width, height), ImageLockMode.WriteOnly, destPixelFormat);
+            try
+            {
+                // BitmapData.Stride may be negative if the bitmap is bottom up. In this case, BitmapData.Scan0 is the last scan line -> recalculate start of unmanaged memory
+                stride = Math.Abs(dstData.Stride); // use actual stride from GDI Bitmap
+                var dstPtr = dstData.Stride > 0 ? dstData.Scan0 : dstData.Scan0 - ((dstData.Height - 1) * stride);
+                DecompressInternal(jpegBuf, jpegBufSize, dstPtr, stride * height, targetFormat, flags, width, height, stride);
+            }
+            finally
+            {
+                result.UnlockBits(dstData);
+            }
+            if (destPixelFormat == PixelFormat.Format8bppIndexed)
+            {
+                result.Palette = _grayscalePalette;
             }
             return result;
         }
@@ -167,16 +259,60 @@ namespace TurboJpegWrapper
         /// <exception cref="TJException">Throws if underlying decompress function failed</exception>
         /// <exception cref="ObjectDisposedException">Object is disposed and can not be used anymore</exception>
         /// <exception cref="NotSupportedException">Convertion to the requested pixel format can not be performed</exception>
-        public unsafe Bitmap Decompress(byte[] jpegBuf, PixelFormat destPixelFormat, TJFlags flags)
+        public Bitmap Decompress(byte[] jpegBuf, PixelFormat destPixelFormat, TJFlags flags)
         {
             if (_isDisposed)
                 throw new ObjectDisposedException("this");
 
             var jpegBufSize = (ulong)jpegBuf.Length;
-            fixed (byte* jpegPtr = jpegBuf)
-            {
-                return Decompress((IntPtr)jpegPtr, jpegBufSize, destPixelFormat, flags);
-            }
+            using (var jpegBufPtr = new TJUnmanagedMemory(jpegBuf))
+                return Decompress(jpegBufPtr, jpegBufSize, destPixelFormat, flags);
+        }
+
+        /// <summary>
+        /// Decompress a JPEG image to an RGB, grayscale, or CMYK image.
+        /// </summary>
+        /// <param name="jpegBuf">A buffer containing the JPEG image to decompress. This buffer is not modified</param>
+        /// <returns>Decompressed image of specified format</returns>
+        /// <exception cref="TJException">Throws if underlying decompress function failed</exception>
+        /// <exception cref="ObjectDisposedException">Object is disposed and can not be used anymore</exception>
+        /// <exception cref="NotSupportedException">Convertion to the requested pixel format can not be performed</exception>
+        public Bitmap Decompress(byte[] jpegBuf)
+        {
+            if (_isDisposed)
+                throw new ObjectDisposedException("this");
+
+            var jpegBufSize = (ulong)jpegBuf.Length;
+            using (var jpegBufPtr = new TJUnmanagedMemory(jpegBuf))
+                return Decompress(jpegBufPtr, jpegBufSize);
+        }
+
+        /// <summary>
+        /// Retrieve information about a JPEG image without decompressing it.
+        /// </summary>
+        /// <param name="jpegBuf">
+        /// Buffer containing a JPEG image.  This buffer is not modified.
+        /// </param>
+        /// <param name="destPixelFormat">
+        /// The pixel format of the uncompressed image.
+        /// </param>
+        /// <param name="width">
+        /// Pointer to an integer variable that will receive the width (in pixels) of the JPEG image
+        /// </param>
+        /// <param name="height">
+        /// Pointer to an integer variable that will receive the height (in pixels) of the JPEG image
+        /// </param>
+        /// <param name="stride">
+        /// Pointer to an integer variable that will receive the stride (in bytes) of the JPEG image.
+        /// </param>
+        /// <param name="bufSize">
+        /// The size of a buffer that can receive the uncompressed JPEG image.
+        /// </param>
+        public void GetImageInfo(byte[] jpegBuf, TJPixelFormats destPixelFormat, out int width, out int height, out int stride, out int bufSize)
+        {
+            var jpegBufSize = (ulong)jpegBuf.Length;
+            using (var jpegBufPtr = new TJUnmanagedMemory(jpegBuf))
+                GetImageInfo(jpegBufPtr, jpegBufSize, destPixelFormat, out width, out height, out stride, out bufSize);
         }
 
         /// <summary>
@@ -211,6 +347,82 @@ namespace TurboJpegWrapper
             var funcResult = TurboJpegImport.tjDecompressHeader(_decompressorHandle, jpegBuf, jpegBufSize,
                 out width, out height, out subsampl, out colorspace);
 
+            if (funcResult == -1)
+            {
+                TJUtils.GetErrorAndThrow();
+            }
+
+            stride = TurboJpegImport.TJPAD(width * TurboJpegImport.PixelSizes[destPixelFormat]);
+            bufSize = stride * height;
+        }
+
+        /// <summary>
+        /// Retrieve information about a JPEG image without decompressing it.
+        /// </summary>
+        /// <param name="jpegBuf">
+        /// Buffer containing a JPEG image. This buffer is not modified.
+        /// </param>
+        /// <param name="destPixelFormat">
+        /// Pointer to a variable that will receive the pixel format of the uncompressed image.
+        /// </param>
+        /// <param name="width">
+        /// Pointer to an integer variable that will receive the width (in pixels) of the JPEG image
+        /// </param>
+        /// <param name="height">
+        /// Pointer to an integer variable that will receive the height (in pixels) of the JPEG image
+        /// </param>
+        /// <param name="stride">
+        /// Pointer to an integer variable that will receive the stride (in bytes) of the JPEG image.
+        /// </param>
+        /// <param name="bufSize">
+        /// The size of a buffer that can receive the uncompressed JPEG image.
+        /// </param>
+        public void GetImageInfo(byte[] jpegBuf, out TJPixelFormats destPixelFormat, out int width, out int height, out int stride, out int bufSize)
+        {
+            var jpegBufSize = (ulong)jpegBuf.Length;
+            using (var jpegBufPtr = new TJUnmanagedMemory(jpegBuf))
+                GetImageInfo(jpegBufPtr, jpegBufSize, out destPixelFormat, out width, out height, out stride, out bufSize);
+        }
+
+        /// <summary>
+        /// Retrieve information about a JPEG image without decompressing it.
+        /// </summary>
+        /// <param name="jpegBuf">
+        /// Pointer to a buffer containing a JPEG image. This buffer is not modified.
+        /// </param>
+        /// <param name="jpegBufSize">
+        /// Size of the JPEG image (in bytes)
+        /// </param>
+        /// <param name="destPixelFormat">
+        /// Pointer to a variable that will receive the pixel format of the uncompressed image.
+        /// </param>
+        /// <param name="width">
+        /// Pointer to an integer variable that will receive the width (in pixels) of the JPEG image
+        /// </param>
+        /// <param name="height">
+        /// Pointer to an integer variable that will receive the height (in pixels) of the JPEG image
+        /// </param>
+        /// <param name="stride">
+        /// Pointer to an integer variable that will receive the stride (in bytes) of the JPEG image.
+        /// </param>
+        /// <param name="bufSize">
+        /// The size of a buffer that can receive the uncompressed JPEG image.
+        /// </param>
+        public void GetImageInfo(IntPtr jpegBuf, ulong jpegBufSize, out TJPixelFormats destPixelFormat, out int width, out int height, out int stride, out int bufSize)
+        {
+            int subsampl;
+            int colorspace;
+
+            var funcResult = TurboJpegImport.tjDecompressHeader(_decompressorHandle, jpegBuf, jpegBufSize,
+                out width, out height, out subsampl, out colorspace);
+
+            if (funcResult == -1)
+            {
+                TJUtils.GetErrorAndThrow();
+            }
+
+            // Since JPEG can only be 8 or 24 bit, select TJPF_GRAY when both colorspace and subsampling say that there is no color information, otherwise use normal windows TJPF_BGR format
+            destPixelFormat = (TJColorSpaces)colorspace == TJColorSpaces.TJCS_GRAY && (TJSubsamplingOptions)subsampl == TJSubsamplingOptions.TJSAMP_GRAY ? TJPixelFormats.TJPF_GRAY : TJPixelFormats.TJPF_BGR;
             stride = TurboJpegImport.TJPAD(width * TurboJpegImport.PixelSizes[destPixelFormat]);
             bufSize = stride * height;
         }
@@ -234,15 +446,6 @@ namespace TurboJpegWrapper
         {
             int stride = TurboJpegImport.TJPAD(width * TurboJpegImport.PixelSizes[destPixelFormat]);
             return stride * height;
-        }
-
-        private ColorPalette FixPaletteToGrayscale(ColorPalette palette)
-        {
-            for (var index = 0; index < palette.Entries.Length; ++index)
-            {
-                palette.Entries[index] = Color.FromArgb(index, index, index);
-            }
-            return palette;
         }
 
         /// <summary>
@@ -291,7 +494,5 @@ namespace TurboJpegWrapper
         {
             Dispose(false);
         }
-
     }
-
 }

--- a/LibJpegWrapper/TJTransformer.cs
+++ b/LibJpegWrapper/TJTransformer.cs
@@ -97,7 +97,7 @@ namespace TurboJpegWrapper
                     customFilter = transforms[i].CustomFilter
                 };
             }
-            var transformsPtr =  TJUtils.StructArrayToIntPtr(tjTransforms);
+            var transformsPtr = TJUtils.StructArrayToIntPtr(tjTransforms);
             try
             {
                 funcResult = TurboJpegImport.tjTransform(_transformHandle, jpegBuf, jpegBufSize, count, destBufs,
@@ -169,17 +169,15 @@ namespace TurboJpegWrapper
         /// <exception cref="ArgumentNullException"><paramref name="transforms"/> is <see langword="null" />.</exception>
         /// <exception cref="ArgumentException">Transforms can not be empty</exception>
         /// <exception cref="TJException"> Throws if low level turbo jpeg function fails </exception>
-        public unsafe byte[][] Transform(byte[] jpegBuf, TJTransformDescription[] transforms, TJFlags flags)
+        public byte[][] Transform(byte[] jpegBuf, TJTransformDescription[] transforms, TJFlags flags)
         {
             if (transforms == null)
                 throw new ArgumentNullException("transforms");
             if (transforms.Length == 0)
                 throw new ArgumentException("Transforms can not be empty", "transforms");
 
-            fixed (byte* jpegPtr = jpegBuf)
-            {
-                return Transform((IntPtr)jpegPtr, (ulong)jpegBuf.Length, transforms, flags);
-            }
+            using (var jpegPtr = new TJUnmanagedMemory(jpegBuf))
+                return Transform(jpegPtr, (ulong)jpegBuf.Length, transforms, flags);
         }
 
         /// <summary>

--- a/LibJpegWrapper/TJUnmanagedMemory.cs
+++ b/LibJpegWrapper/TJUnmanagedMemory.cs
@@ -1,0 +1,128 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace TurboJpegWrapper
+{
+    /// <summary>
+    /// This class wraps a block of unmanaged memory allocated using <see cref="TurboJpegImport.tjAlloc(int)"/>
+    /// ensuring that the memory is freed using <see cref="TurboJpegImport.tjFree(IntPtr)"/> when it is manually
+    /// disposed, goes out of context or is garbage collected. An instance of this class can be implicitly converted
+    /// to either an <see cref="IntPtr"/> or a <see cref="byte[]"/>.
+    /// </summary>
+    /// <seealso cref="System.IDisposable" />
+    public sealed class TJUnmanagedMemory : IDisposable
+    {
+        private bool _isDisposed;
+        private IntPtr _buffer;
+        private ulong _size;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TJUnmanagedMemory"/> class and allocates the 
+        /// requested amount of unmanaged memory using <see cref="TurboJpegImport.tjAlloc(int)"/>.
+        /// </summary>
+        /// <param name="size">The number of bytes of unmanaged memory to allocate.</param>
+        public TJUnmanagedMemory(int size)
+        {
+            if (size < 0)
+                throw new ArgumentOutOfRangeException(nameof(size));
+            _buffer = TurboJpegImport.tjAlloc(size);
+            if (_buffer == IntPtr.Zero)
+                throw new OutOfMemoryException("Could not allocate memory for buffer");
+            _size = (ulong)size;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TJUnmanagedMemory"/> class without allocating
+        /// new memory.
+        /// </summary>
+        /// <param name="buffer">The buffer to wrap (must be allocated using <see cref="TurboJpegImport.tjAlloc(int)"/> or returned from a native TJ method).</param>
+        /// <param name="size">The size of the buffer (in bytes).</param>
+        internal TJUnmanagedMemory(IntPtr buffer, ulong size)
+        {
+            _buffer = buffer;
+            _size = size;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TJUnmanagedMemory"/> class, allocating memory for the bytes
+        /// int the providied array and copying them to the unmanaged memory using <see cref="Marshal.Copy(byte[], int, IntPtr, int)"/>.
+        /// </summary>
+        /// <param name="buffer">The buffer which to convert to unmanaged memory.</param>
+        internal TJUnmanagedMemory(byte[] buffer)
+            :this(buffer.Length)
+        {
+            Marshal.Copy(buffer, 0, _buffer, (int)_size);
+        }
+
+        /// <summary>
+        /// Gets the size of the allocated native memory block (in bytes).
+        /// </summary>
+        /// <value>
+        /// The size.
+        /// </value>
+        public int Size { get { return (int)_size; } }
+
+        /// <summary>
+        /// Performs an implicit conversion from <see cref="TJUnmanagedMemory"/> to <see cref="IntPtr"/>.
+        /// </summary>
+        /// <param name="source">The source object to convert.</param>
+        /// <returns>
+        /// The result of the conversion.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">source</exception>
+        /// <exception cref="ObjectDisposedException">this</exception>
+        public static implicit operator IntPtr(TJUnmanagedMemory source)
+        {
+            if (source == null)
+                throw new ArgumentNullException(nameof(source));
+            if (source._isDisposed)
+                throw new ObjectDisposedException("this");
+            return source._buffer;
+        }
+
+        /// <summary>
+        /// Performs an implicit conversion from <see cref="TJUnmanagedMemory"/> to <see cref="byte[]" />.
+        /// </summary>
+        /// <param name="source">The source object to convert.</param>
+        /// <returns>
+        /// The result of the conversion.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">source</exception>
+        /// <exception cref="ObjectDisposedException">this</exception>
+        public static implicit operator byte[](TJUnmanagedMemory source)
+        {
+            if (source == null)
+                throw new ArgumentNullException(nameof(source));
+            if (source._isDisposed)
+                throw new ObjectDisposedException("this");
+            var buffer = new byte[source._size];
+            Marshal.Copy(source._buffer, buffer, 0, (int)source._size);
+            return buffer;
+        }
+
+        #region IDisposable Support
+        private void Dispose(bool disposing)
+        {
+            if (!_isDisposed)
+            {
+                if (_buffer != IntPtr.Zero)
+                    TurboJpegImport.tjFree(_buffer);
+                _isDisposed = true;
+                _buffer = IntPtr.Zero;
+                _size = 0;
+            }
+        }
+
+        ~TJUnmanagedMemory()
+        {
+            Dispose(false);
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+        #endregion
+    }
+}

--- a/LibJpegWrapper/TJUtils.cs
+++ b/LibJpegWrapper/TJUtils.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 namespace TurboJpegWrapper
 {
     // ReSharper disable once InconsistentNaming
-    static class TJUtils
+    public static class TJUtils
     {
         ///<summary>
         /// Retrieves last error from underlying turbo-jpeg library and throws exception</summary>

--- a/LibJpegWrapper/TJUtils.cs
+++ b/LibJpegWrapper/TJUtils.cs
@@ -16,6 +16,7 @@ namespace TurboJpegWrapper
             var error = TurboJpegImport.tjGetErrorStr();
             throw new TJException(error);
         }
+
         /// <summary>
         /// Converts pixel format from <see cref="PixelFormat"/> to <see cref="TJPixelFormats"/>
         /// </summary>
@@ -32,6 +33,27 @@ namespace TurboJpegWrapper
                     return TJPixelFormats.TJPF_BGR;
                 case PixelFormat.Format8bppIndexed:
                     return TJPixelFormats.TJPF_GRAY;
+                default:
+                    throw new NotSupportedException($"Provided pixel format \"{pixelFormat}\" is not supported");
+            }
+        }
+
+        /// <summary>
+        /// Converts pixel format from <see cref="TJPixelFormats"/> to <see cref="PixelFormat"/>
+        /// </summary>
+        /// <param name="pixelFormat">Pixel format to convert</param>
+        /// <returns>Converted value of pixel format or exception if convertion is impossible</returns>
+        /// <exception cref="NotSupportedException">Convertion can not be performed</exception>
+        public static PixelFormat ConvertPixelFormat(TJPixelFormats pixelFormat)
+        {
+            switch (pixelFormat)
+            {
+                case TJPixelFormats.TJPF_BGRA:
+                    return PixelFormat.Format32bppArgb;
+                case TJPixelFormats.TJPF_BGR:
+                    return PixelFormat.Format24bppRgb;
+                case TJPixelFormats.TJPF_GRAY:
+                    return PixelFormat.Format8bppIndexed;
                 default:
                     throw new NotSupportedException($"Provided pixel format \"{pixelFormat}\" is not supported");
             }


### PR DESCRIPTION
The decompress interface did not allow getting the necessary information from the JPEG header to determine which parameters to use for the decompression call. As far as I can tell, the JPEG file format supports either 8 bit or 24 bit images. To be able to load an image file "as is", one must be able to determine which of these cases are to be applied for the current image file.
Furthermore, I oppose the usage of the "unsafe" keyword on principle and mapping of managed memory directly to use in an unmanaged context and have therefore refactored the necessary parts.
With the changes from this fork, it is now possible to simply decompress a JPEG bytestream (without conversion) to a  System.Drawing.Bitmap, as well as querying the format of the JPEG stream and allocating a suitable Bitmap object (for example from a pool for memory conservation) and decompress to it.